### PR TITLE
Pin GitHub Actions to SHAs [SRE-1802]

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: "1.20"
       - name: Go linter
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3
         with:
           version: v1.55
       - name: Run tests


### PR DESCRIPTION
## Summary
Pin GitHub Actions references in this repo to immutable commit SHAs (with the original tag/branch preserved in a trailing comment). Part of [SRE-1802](https://ciqinc.atlassian.net/browse/SRE-1802) — org-wide supply-chain hardening.

## Scope
This PR pins:
- Internal `ctrliq/*` reusable workflow and action references
- External actions **not** handled by clo-ciq's parallel Node 20 effort

_No actions in this repo were claimed by clo-ciq's effort — this PR pins everything._

## Files touched

- `.github/workflows/test.yaml`

## Test plan
- [ ] Workflow runs succeed on this branch (or on next trigger after merge)
- [ ] Once this and any companion clo-ciq PR merge, this repo has zero unpinned external/internal refs and `sha_pinning_required` can be enabled on it

[SRE-1802]: https://ciqinc.atlassian.net/browse/SRE-1802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ